### PR TITLE
Fix typo in link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ All checks are based on [Rakpart](https://rakpart.testthedocs.org)
 
 ## Documentation
 
-Read the documentation on the [website](https://edic.testthhedocs.org).
+Read the documentation on the [website](https://edic.testthedocs.org).
 
 ## Usage
 


### PR DESCRIPTION
Fixed typo in hyperlink. See diff.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/testthedocs/edic/20)
<!-- Reviewable:end -->
